### PR TITLE
storable partner_id field for subquery

### DIFF
--- a/addons/mass_mailing/models/mailing.py
+++ b/addons/mass_mailing/models/mailing.py
@@ -439,7 +439,7 @@ class MassMailing(models.Model):
         """
 
         # Apply same 'get email field' rule from mail_thread.message_get_default_recipients
-        if 'partner_id' in target._fields:
+        if 'partner_id' in target._fields and target._fields['partner_id'].store:
             mail_field = 'email'
             query = """
                 SELECT lower(substring(p.%(mail_field)s, '([^ ,;<@]+@[^> ,;]+)'))

--- a/doc/cla/individual/grzana12.md
+++ b/doc/cla/individual/grzana12.md
@@ -1,0 +1,11 @@
+Poland, 2022-05-04
+
+I hereby agree to the terms of the Odoo Individual Contributor License
+Agreement v1.0.
+
+I declare that I am authorized and able to make this agreement and sign this
+declaration.
+
+Signed,
+
+Łukasz Grzenkowicz lukasz@grzana.pl https://github.com/grzana12


### PR DESCRIPTION
Description of the issue/feature this PR addresses:
after made customization where we need in `mailing.contact.subscription` value of `partner_id` Odoo generate internal Server Error.
Please merge it to 13.0 too

Current behavior before PR:
after added field `partner_id` to model `mailing.contact.subscription` which is not storable application generate 500 error

Desired behavior after PR is merged:
`partner_id` is not storable in result first condition is skipped what is fine



--
I confirm I have signed the CLA and read the PR guidelines at www.odoo.com/submit-pr